### PR TITLE
ci: add typecheck and build to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,12 @@ jobs:
       - run: npm run lint
 
       - run: npm test
+
+      - run: npm run typecheck
+
+      - run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-stub-anon-key
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+          SUPABASE_SERVICE_ROLE_KEY: ci-stub-service-role-key

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,9 +223,9 @@ export async function saveItem(formData: FormData) {
 
 ### Current Status
 
-- **No automated testing framework** is currently configured
-- **Manual testing** is required for all changes
-- **Future**: Jest/Vitest + React Testing Library planned
+- **Vitest** unit tests (`npm test`) run locally and in CI
+- **CI on pull requests** runs: lint, test, typecheck, and production build
+- **Manual testing** is still recommended for UI and admin flows
 
 ### Manual Testing Checklist
 
@@ -240,15 +240,12 @@ Before submitting a PR, verify:
 
 ### Testing Commands
 
+Run these before opening a PR (CI runs the same checks, plus `npm run build`):
+
 ```bash
-# Run type checking
-npm run build
-
-# Run linting
 npm run lint
-
-# Test database connection
-npx ts-node src/lib/supabase.test.ts
+npm test
+npm run typecheck
 ```
 
 ## 📝 Commit Message Format

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,7 @@ We welcome contributions to the OpenQase project! Please follow these guidelines
 ## Development Process
 
 1.  **Code:** Make your changes, following the coding standards below.
-2.  **Test:** Manually test your changes thoroughly. Run `npm run lint` to check code quality.
+2.  **Test:** Run `npm run lint`, `npm test`, and `npm run typecheck` before opening a PR. Manually test UI and admin changes as needed.
 3.  **Update Documentation:** If your changes affect user-facing features, APIs, or the development setup, please update the relevant documentation pages within `/docs`.
 4.  **Update Migrations:** If you make database schema changes, create a new migration file in `supabase/migrations/`.
 5.  **Commit:** Use clear and descriptive commit messages. Reference the relevant issue number (e.g., `feat: Add user profile page (#123)`).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit --skipLibCheck",
     "setup-admin": "tsx scripts/setup-admin.ts",
     "test-performance": "node scripts/page-load-performance.js",
     "enable-dev-mode": "node scripts/enable-dev-mode.js",


### PR DESCRIPTION
## Summary
Updates the CI pipeline to run typecheck and build after the existing lint and test steps, so pull requests catch TypeScript and production-build errors before merge.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [x] Other: CI tooling

## Changes Made
- Added a typecheck script to package.json using tsc --noEmit --skipLibCheck
- Extended .github/workflows/ci.yml to run npm run typecheck and npm run build
- Added stub environment variables in CI so the production build can run in GitHub Actions without real secrets
- Updated CONTRIBUTING.md and docs/contributing.md to document the current local and CI test workflow

## Testing
Tested locally by running the same pipeline steps that CI now uses:
```
npm ci
npm run lint
npm test
npm run typecheck
NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
NEXT_PUBLIC_SUPABASE_ANON_KEY=ci-stub-anon-key \
NEXT_PUBLIC_SITE_URL=http://localhost:3000 \
SUPABASE_SERVICE_ROLE_KEY=ci-stub-service-role-key \
npm run build
```
- npm run lint produced warnings but no errors
- npm test passed
- npm run typecheck passed (no output)
- npm run build completed successfully with stub supabase env. (Build logs expected Fetch errors because of the stubbed env, but these don't fail the build, which mirrors expected behavior.)
This was to make sure that new CI pipeline does not fail on issues that are already present in the code, allowing it to accurately flag issues upon subsequent PR creation.