### PR TITLE
fix(csp): allow local Supabase connects in development

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,25 @@ import type { NextConfig } from "next";
 // Use NEXT_STATIC_EXPORT=true for full static export (public sites only)
 const isFullStaticExport = process.env.NEXT_STATIC_EXPORT === 'true';
 
+// Production CSP only allows cloud Supabase. Local API (e.g. 127.0.0.1:54321)
+// must be permitted in development or browser fetches fail with CSP violations.
+const connectSrc = [
+  "'self'",
+  ...(process.env.NODE_ENV === 'development'
+    ? [
+        'http://127.0.0.1:*',
+        'http://localhost:*',
+        'ws://127.0.0.1:*',
+        'ws://localhost:*',
+      ]
+    : []),
+  'https://*.supabase.co',
+  'https://*.supabase.com',
+  'https://o4507902208450560.ingest.us.sentry.io',
+  'wss://*.supabase.co',
+  'https://vitals.vercel-insights.com',
+].join(' ');
+
 const nextConfig: NextConfig = {
   // Only use full static export when explicitly requested
   ...(isFullStaticExport && {
@@ -114,7 +133,7 @@ const nextConfig: NextConfig = {
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "font-src 'self' https://fonts.gstatic.com",
               "img-src 'self' data: blob: https:",
-              "connect-src 'self' https://*.supabase.co https://*.supabase.com https://o4507902208450560.ingest.us.sentry.io wss://*.supabase.co https://vitals.vercel-insights.com",
+              `connect-src ${connectSrc}`,
               "worker-src 'self' blob:",
               "frame-src 'self' https://vercel.live",
               "frame-ancestors 'none'",


### PR DESCRIPTION
## Summary
Allows the browser to talk to local Supabase during `npm run dev` by extending CSP `connect-src` for `localhost` / `127.0.0.1` (HTTP + WebSocket). Production CSP stays unchanged. This arose from an issue with local development where trying to sign in threw "Failed to Fetch" errors, preventing testing on admin publishing workflows. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Changes Made
- Builds `connect-src` in `next.config.ts` from a shared list
- When `NODE_ENV === 'development'`, appends `http://127.0.0.1:*`, `http://localhost:*`, and matching `ws://` entries
- Leaves production `connect-src` as is

## Testing
- Confirmed `next dev` response CSP includes local hosts in `connect-src`
- Confirmed production/`next start` CSP does **not** include local hosts (expected; local Supabase + `next start` still CSP-blocked by design)
- Manually ran auth workflows (e.g. signing in) against local Supabase under `npm run dev` 