### PR TITLE
fix(db): set technology_type for the archive stragglers

### DIFF
--- a/supabase/migrations/20260718_set_straggler_technology_types.sql
+++ b/supabase/migrations/20260718_set_straggler_technology_types.sql
@@ -1,0 +1,20 @@
+-- Set technology_type for the hardware not covered by the archive restore
+-- (20260717_restore_technology_type_freetext). Values confirmed from public
+-- sources. Two are modalities the hardware_modality enum can't represent
+-- (kept as free text), which is why technology_type stays a text column.
+--
+-- The placeholder rows 'na' / 'not-applicable' are intentionally left NULL
+-- (not real hardware; a separate deletion decision).
+
+UPDATE public.quantum_hardware AS h
+SET technology_type = v.technology_type
+FROM (VALUES
+  ('ibm-heron', 'Superconducting'),
+  ('ibm-marrakech', 'Superconducting'),
+  ('ibm-torino', 'Superconducting'),
+  ('ibm-quantum-casablanca', 'Superconducting'),
+  ('ibm-quantum-melbourne', 'Superconducting'),
+  ('c12-carbon-nanotube-qpu', 'Spin qubit (carbon nanotube)'),
+  ('nord-quantum-bosonic-system', 'Bosonic')
+) AS v(slug, technology_type)
+WHERE h.slug = v.slug;


### PR DESCRIPTION
Follow-up to #230. Sets `technology_type` for the 7 hardware rows not covered by the archive restore:

| slug | technology_type |
|------|-----------------|
| ibm-heron, ibm-marrakech, ibm-torino, ibm-quantum-casablanca, ibm-quantum-melbourne | Superconducting |
| c12-carbon-nanotube-qpu | Spin qubit (carbon nanotube) |
| nord-quantum-bosonic-system | Bosonic |

The two placeholder rows (`na`, `not-applicable`) are intentionally left NULL — not real hardware, separate deletion decision.

Tracked migration; apply to prod and record in the ledger (`20260718`, `set_straggler_technology_types`). Only touches `technology_type` on those 7 slugs — no deletes, no other columns.