### PR TITLE
fix(admin): restore freetext technology_type

### DIFF
--- a/src/app/admin/quantum-hardware/[id]/actions.ts
+++ b/src/app/admin/quantum-hardware/[id]/actions.ts
@@ -68,18 +68,34 @@ export const loadHardwareSpecs = withAdmin(
   }
 )
 
+function normalizeSpecKey(key: string): string {
+  return key
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 64)
+}
+
 export const saveHardwareSpecs = withAdmin(
   async (hardwareId: string, rows: HardwareSpecInput[]): Promise<void> => {
     const supabase = createServiceRoleSupabaseClient()
     const cleaned = rows
       .map((row) => ({
-        spec_key: row.spec_key.trim(),
+        spec_key: normalizeSpecKey(row.spec_key),
         value: row.value.trim(),
         unit: row.unit?.trim() ? row.unit.trim() : null,
       }))
       .filter((row) => row.spec_key.length > 0 && row.value.length > 0)
 
     const keys = cleaned.map((row) => row.spec_key)
+    const seen = new Set<string>()
+    for (const key of keys) {
+      if (seen.has(key)) {
+        throw new Error(`Duplicate spec key "${key}". Each spec key must be unique.`)
+      }
+      seen.add(key)
+    }
 
     if (keys.length === 0) {
       const { error: deleteAllError } = await supabase

--- a/src/app/admin/quantum-hardware/[id]/client.tsx
+++ b/src/app/admin/quantum-hardware/[id]/client.tsx
@@ -8,13 +8,6 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Switch } from '@/components/ui/switch'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { PublishButton } from '@/components/admin/PublishButton'
 import { ContentCompleteness } from '@/components/admin/ContentCompleteness'
 import {
@@ -31,12 +24,6 @@ import {
   unpublishQuantumHardware,
   saveHardwareSpecs,
 } from './actions'
-import {
-  HARDWARE_MODALITIES,
-  HARDWARE_MODALITY_LABELS,
-  isHardwareModality,
-  type HardwareModality,
-} from '@/lib/hardware-modality'
 import type { Database } from '@/types/supabase'
 
 type SpecDefinition = Database['public']['Tables']['hardware_spec_definitions']['Row']
@@ -88,10 +75,6 @@ export function QuantumHardwareForm({
 
   const validationRules = createContentValidationRules('quantum_hardware')
   const completionPercentage = calculateCompletionPercentage({ values, validationRules })
-
-  const modality: HardwareModality | null = isHardwareModality(values.technology_type)
-    ? values.technology_type
-    : null
 
   const handleChange = (field: string, value: any) => {
     setValues(prev => ({ ...prev, [field]: value }))
@@ -306,21 +289,13 @@ export function QuantumHardwareForm({
               </div>
               <div>
                 <Label htmlFor="technology_type">Technology Type</Label>
-                <Select
-                  value={values.technology_type || undefined}
-                  onValueChange={(value) => handleChange('technology_type', value)}
-                >
-                  <SelectTrigger id="technology_type" className="mt-1">
-                    <SelectValue placeholder="Select modality" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {HARDWARE_MODALITIES.map((mod) => (
-                      <SelectItem key={mod} value={mod}>
-                        {HARDWARE_MODALITY_LABELS[mod]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Input
+                  id="technology_type"
+                  value={values.technology_type}
+                  onChange={(e) => handleChange('technology_type', e.target.value)}
+                  placeholder="e.g., Superconducting"
+                  className="mt-1"
+                />
               </div>
             </div>
 
@@ -442,7 +417,7 @@ export function QuantumHardwareForm({
         </CardHeader>
         <CardContent className="p-6 pt-0">
           <HardwareSpecsEditor
-            modality={modality}
+            modality={null}
             definitions={definitions}
             rows={specRows}
             onChange={setSpecRows}

--- a/src/cms/types/quantum-hardware.ts
+++ b/src/cms/types/quantum-hardware.ts
@@ -1,5 +1,4 @@
 import { defineContentType } from '../define'
-import { HARDWARE_MODALITIES } from '@/lib/hardware-modality'
 
 export const quantumHardware = defineContentType({
   slug: 'quantum-hardware',
@@ -13,11 +12,7 @@ export const quantumHardware = defineContentType({
     { name: 'description', type: 'textarea', maxLength: 1000 },
     { name: 'main_content', type: 'markdown' },
     { name: 'vendor', type: 'text' },
-    {
-      name: 'technology_type',
-      type: 'select',
-      options: [...HARDWARE_MODALITIES],
-    },
+    { name: 'technology_type', type: 'text' },
     { name: 'qubit_count', type: 'number' },
     { name: 'connectivity', type: 'text' },
     { name: 'gate_fidelity', type: 'number' },

--- a/src/components/admin/HardwareSpecsEditor.tsx
+++ b/src/components/admin/HardwareSpecsEditor.tsx
@@ -129,52 +129,52 @@ export function HardwareSpecsEditor({
     onChange(rows.filter((row) => row.clientId !== clientId))
   }
 
-  if (!modality) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Select a technology type above to see modality-specific preset specs.
-      </p>
-    )
-  }
-
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant="secondary">{HARDWARE_MODALITY_LABELS[modality]}</Badge>
-        <span className="text-sm text-muted-foreground">
-          Presets follow the technology type from Basic Information.
-        </span>
-      </div>
+      {modality ? (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary">{HARDWARE_MODALITY_LABELS[modality]}</Badge>
+            <span className="text-sm text-muted-foreground">
+              Suggested specs for this modality.
+            </span>
+          </div>
 
-      <div className="space-y-3">
-        <div className="flex items-center justify-between gap-4">
-          <Label>Add preset spec</Label>
-          <span className="text-xs text-muted-foreground">
-            {availablePresets.length} available for {HARDWARE_MODALITY_LABELS[modality]}
-          </span>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {availablePresets.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              All presets for this modality are already in the table.
-            </p>
-          ) : (
-            availablePresets.map((def) => (
-              <Button
-                key={def.spec_key}
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={disabled}
-                onClick={() => addPreset(def)}
-              >
-                <Plus className="mr-1 h-3 w-3" />
-                {def.label}
-              </Button>
-            ))
-          )}
-        </div>
-      </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-4">
+              <Label>Add preset spec</Label>
+              <span className="text-xs text-muted-foreground">
+                {availablePresets.length} available for {HARDWARE_MODALITY_LABELS[modality]}
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {availablePresets.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  All presets for this modality are already in the table.
+                </p>
+              ) : (
+                availablePresets.map((def) => (
+                  <Button
+                    key={def.spec_key}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => addPreset(def)}
+                  >
+                    <Plus className="mr-1 h-3 w-3" />
+                    {def.label}
+                  </Button>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Add custom specs below. Preset specs will be available when a modality is set.
+        </p>
+      )}
 
       <div className="rounded-lg border border-border overflow-hidden">
         <Table>
@@ -190,7 +190,9 @@ export function HardwareSpecsEditor({
             {rows.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={4} className="text-center text-muted-foreground py-8">
-                  No specs added yet. Choose a preset above or add a custom row.
+                  {modality
+                    ? 'No specs added yet. Choose a preset above or add a custom row.'
+                    : 'No specs added yet. Add a custom row below.'}
                 </TableCell>
               </TableRow>
             ) : (

--- a/src/components/admin/HardwareSpecsEditor.tsx
+++ b/src/components/admin/HardwareSpecsEditor.tsx
@@ -17,6 +17,7 @@ import { Plus, Trash2 } from 'lucide-react'
 import type { Database } from '@/types/supabase'
 import type { HardwareModality } from '@/lib/hardware-modality'
 import { HARDWARE_MODALITY_LABELS } from '@/lib/hardware-modality'
+import { cn } from '@/lib/utils'
 
 type SpecDefinition = Database['public']['Tables']['hardware_spec_definitions']['Row']
 
@@ -36,13 +37,38 @@ interface HardwareSpecsEditorProps {
   disabled?: boolean
 }
 
-function slugifyCustomKey(label: string): string {
+/** While typing: allow a trailing `_` so keys like `test_2` can be entered after `test`. */
+function slugifyCustomKeyInput(label: string): string {
   return label
     .toLowerCase()
-    .trim()
     .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
+    .replace(/^_+/, '')
     .slice(0, 64)
+}
+
+/** On blur / finalize: strip edge underscores. */
+function finalizeCustomKey(label: string): string {
+  return slugifyCustomKeyInput(label).replace(/_+$/g, '')
+}
+
+function customKeyConflict(
+  clientId: string,
+  specKey: string,
+  rows: HardwareSpecDraft[],
+  definitionByKey: Map<string, SpecDefinition>
+): string | null {
+  if (!specKey) return null
+  if (definitionByKey.has(specKey)) {
+    return 'This key matches a preset spec. Choose a different key or add it from presets.'
+  }
+  const lower = specKey.toLowerCase()
+  const duplicate = rows.some(
+    (r) => r.clientId !== clientId && r.spec_key.toLowerCase() === lower
+  )
+  if (duplicate) {
+    return 'Another row already uses this key.'
+  }
+  return null
 }
 
 function newClientId(): string {
@@ -199,6 +225,9 @@ export function HardwareSpecsEditor({
               rows.map((row) => {
                 const def = definitionByKey.get(row.spec_key)
                 const isPreset = Boolean(def)
+                const conflict = isPreset
+                  ? null
+                  : customKeyConflict(row.clientId, row.spec_key, rows, definitionByKey)
 
                 return (
                   <TableRow key={row.clientId}>
@@ -209,26 +238,32 @@ export function HardwareSpecsEditor({
                           <p className="text-xs text-muted-foreground font-mono">{row.spec_key}</p>
                         </div>
                       ) : (
-                        <Input
-                          value={row.spec_key}
-                          disabled={disabled}
-                          onChange={(e) => {
-                            const nextKey = slugifyCustomKey(e.target.value)
-                            if (definitionByKey.has(nextKey)) return
-                            if (
-                              rows.some(
-                                (r) =>
-                                  r.clientId !== row.clientId &&
-                                  r.spec_key.toLowerCase() === nextKey.toLowerCase()
-                              )
-                            ) {
-                              return
-                            }
-                            updateRow(row.clientId, { spec_key: nextKey })
-                          }}
-                          placeholder="custom_spec_key"
-                          className="font-mono text-sm"
-                        />
+                        <div className="space-y-1">
+                          <Input
+                            value={row.spec_key}
+                            disabled={disabled}
+                            onChange={(e) => {
+                              updateRow(row.clientId, {
+                                spec_key: slugifyCustomKeyInput(e.target.value),
+                              })
+                            }}
+                            onBlur={() => {
+                              const finalized = finalizeCustomKey(row.spec_key)
+                              if (finalized !== row.spec_key) {
+                                updateRow(row.clientId, { spec_key: finalized })
+                              }
+                            }}
+                            placeholder="custom_spec_key"
+                            aria-invalid={Boolean(conflict)}
+                            className={cn(
+                              'font-mono text-sm',
+                              conflict && 'border-destructive focus-visible:ring-destructive'
+                            )}
+                          />
+                          {conflict && (
+                            <p className="text-xs text-destructive">{conflict}</p>
+                          )}
+                        </div>
                       )}
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
## Summary
Restores `technology_type` as free text in the CMS/admin form (matching the DB after #230/#231), and keeps the hardware specs table usable with custom specs when no modality is set. Preset chips are deferred to a dedicated optional `hardware_modality` field (#233).

Also fixes duplicate key handling by removing automatic text input alterations and adding warning border styling + save guards upon key conflicts.

## Related Issue
Related to #233 (will implement follow-up: nullable modality column + preset select). Does not implement that schema change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Changes Made
- CMS: `technology_type` is `text` again (not a modality select)
- Admin: Technology Type is a free-text input (same as pre-#228), guards + UI change added to highlight spec key conflicts
- Specs editor: always show custom specs table; do not derive presets from technology type
- No database migration

## Testing
- Verified Technology Type accepts free-text labels
- Verified custom specs can be added without selecting a modality
- Verified inability to save + warning borders when entering duplicate keys