### PR TITLE
feat(hardware): show static specs table on hardware entries

### DIFF
--- a/src/app/paths/quantum-hardware/[slug]/page.tsx
+++ b/src/app/paths/quantum-hardware/[slug]/page.tsx
@@ -5,10 +5,10 @@ import { Badge } from '@/components/ui/badge';
 import { processMarkdown } from '@/lib/markdown-server';
 import Link from 'next/link';
 import { ExternalLink, FileText, Building2, Cpu, Briefcase } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getRelatedQuantumSoftware, getRelatedQuantumCompanies, getRelatedPartnerCompanies } from '@/lib/relationship-queries';
 import { AutoSchema } from '@/components/AutoSchema';
 import { formatHardwareModality } from '@/lib/hardware-modality';
+import { loadHardwareSpecsForDisplay } from '@/lib/hardware-specs-display';
 type EnrichedQuantumHardware = Database['public']['Tables']['quantum_hardware']['Row'] & {
   case_studies?: { id: string; title: string; slug: string; description: string; published_at: string }[];
 };
@@ -82,10 +82,11 @@ export default async function QuantumHardwareDetailPage({ params }: QuantumHardw
   const caseStudyIds = relatedCaseStudies.map(cs => cs.id);
   
   // Fetch related ecosystem components through case studies
-  const [relatedSoftware, quantumCompanies, partnerCompanies] = await Promise.all([
+  const [relatedSoftware, quantumCompanies, partnerCompanies, hardwareSpecs] = await Promise.all([
     getRelatedQuantumSoftware(caseStudyIds),
     getRelatedQuantumCompanies(caseStudyIds),
-    getRelatedPartnerCompanies(caseStudyIds)
+    getRelatedPartnerCompanies(caseStudyIds),
+    loadHardwareSpecsForDisplay(quantumHardware.id),
   ]);
 
   return (
@@ -203,6 +204,26 @@ export default async function QuantumHardwareDetailPage({ params }: QuantumHardw
           )}
         </div>
       </div>
+
+      {hardwareSpecs.length > 0 && (
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold mb-4">Specifications</h2>
+          <dl className="divide-y divide-border rounded-lg border border-border">
+            {hardwareSpecs.map((spec) => (
+              <div
+                key={spec.spec_key}
+                className="flex flex-col gap-1 px-3 py-2.5 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
+              >
+                <dt className="text-sm font-medium">{spec.label}</dt>
+                <dd className="text-sm text-muted-foreground sm:text-right">
+                  {spec.value}
+                  {spec.unit ? ` ${spec.unit}` : ''}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
 
       {/* Main Content */}
       {processedContent && (

--- a/src/lib/hardware-specs-display.ts
+++ b/src/lib/hardware-specs-display.ts
@@ -1,0 +1,54 @@
+import { createServiceRoleSupabaseClient } from '@/lib/supabase-server'
+
+export type PublicHardwareSpec = {
+  spec_key: string
+  label: string
+  value: string
+  unit: string | null
+}
+
+function humanizeSpecKey(key: string): string {
+  return key
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+/**
+ * Load spec rows for a published hardware detail page.
+ * Uses service role (SSG-safe, no cookies()) — caller must only pass an id
+ * for hardware already verified published + not deleted.
+ */
+export async function loadHardwareSpecsForDisplay(
+  hardwareId: string
+): Promise<PublicHardwareSpec[]> {
+  const supabase = createServiceRoleSupabaseClient()
+
+  const [specsResult, defsResult] = await Promise.all([
+    supabase
+      .from('quantum_hardware_specs')
+      .select('spec_key, value, unit')
+      .eq('hardware_id', hardwareId)
+      .order('spec_key'),
+    supabase.from('hardware_spec_definitions').select('spec_key, label'),
+  ])
+
+  if (specsResult.error) {
+    console.error('Error loading hardware specs:', specsResult.error)
+    return []
+  }
+
+  const labelByKey = new Map(
+    (defsResult.data ?? []).map((def) => [def.spec_key, def.label])
+  )
+
+  return (specsResult.data ?? [])
+    .map((row) => ({
+      spec_key: row.spec_key,
+      label: labelByKey.get(row.spec_key) ?? humanizeSpecKey(row.spec_key),
+      value: row.value,
+      unit: row.unit,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label))
+}


### PR DESCRIPTION
## Summary
Loads `quantum_hardware_specs` (with labels from `hardware_spec_definitions`) table on published quantum hardware detail pages. Renders a read-only **Specifications** definition list when rows exist; omits the section when empty

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (describe):

## Changes Made
- Added src/lib/hardware-specs-display.ts to load quantum_hardware_specs plus definition labels (humanize custom keys; SSG-safe service-role fetch)
- Updated the public hardware detail page to show a read-only Specifications list when specs exist, and hide it when empty (flat header chips unchanged)

## Test plan
- Hardware with saved preset + custom specs shows labels/values/units as expected
- Hardware with no specs: no Specifications section
- Spec with null/empty unit shows value only
- Flat header chips still reflect Basic Info fields